### PR TITLE
Update MacOS section in troubleshooting-ch.md

### DIFF
--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -21,7 +21,7 @@ The following information might help you troubleshoot common issues when using t
 1. Find your Git configuration file\. You can use the git option `--show-origin` to find out the config file where Mac OS X Keychain credential helper is defined:
 
    ```
-   $ git config -l —show-origin
+   $ git config -l --show-origin
    ```
    
 1. Find a file with option `helper = osxkeychain` and edit it.

--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -18,15 +18,13 @@ The following information might help you troubleshoot common issues when using t
 
  The default version of Git released on OS X and macOS uses the Keychain Access utility to save generated credentials\. For security reasons, the password generated for access to your AWS CodeCommit repository is temporary, so the credentials stored in the keychain will stop working after about 15 minutes\. If you are only accessing Git with AWS CodeCommit, try the following:
 
-1. Using Terminal, determine where Git is installed on the local machine:
+1. Find your Git configuration file\. You can use the git option `--show-origin` to find out the config file where Mac OS X Keychain credential helper is defined:
 
    ```
-   $ which git
+   $ git config -l —show-origin
+   ```
    
-   /usr/local/git/bin/git
-   ```
-
-1. Find your Git configuration file\. You can use the Finder utility or you can use the find command with superuser permissions \(for example, $ sudo find \~ \-name "\.gitconfig"\)\. Edit the Git config file:
+1. Find a file with option `helper = osxkeychain` and edit it.
 
    ```
    $ nano /usr/local/git/etc/gitconfig
@@ -36,6 +34,13 @@ The following information might help you troubleshoot common issues when using t
 
    ```
    # helper = osxkeychain
+   ```
+   
+1. Alternatively, if you want to cache credentials for other services change the `[credential]` header. For example, the following configuration allows to cache GitHub credentials only:
+
+   ```
+   [credential "https://github.com"]
+        helper = osxkeychain
    ```
 
 If, however, you are accessing other repositories with Git, you can configure the Keychain Access utility so that it does not supply credentials for your AWS CodeCommit repositories\. To configure the Keychain Access utility:


### PR DESCRIPTION
*Description of changes:*
Update the "Troubleshooting the Credential Helper" guide with more straightforward way to find git config files and alternative approach how to preserve caching functionality based on repository URL. More info can be found in related git documentation:
* https://git-scm.com/docs/git-config#git-config---show-origin
* https://git-scm.com/docs/gitcredentials

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
