### PR TITLE
Change cross account aws cli profile configuration

### DIFF
--- a/doc_source/cross-account-user-b.md
+++ b/doc_source/cross-account-user-b.md
@@ -54,7 +54,7 @@ AWS CodeCommit supports Git versions 1\.7\.9 and later\. Git is an evolving, reg
    output = json
    ```
 
-   Add two lines to the profile configuration, `role_arn` and `source_profile`\. Provide the ARN of the role in AccountA you will assume to access the repository in the other account, and the name of the current profile\. For example:
+   Add two lines to the profile configuration, `role_arn` and `source_profile`\. Provide the ARN of the role in AccountA you will assume to access the repository in the other account, and the name of the AWS CLI credential profile in account B\. For example:
 
    ```
    [profile MyCrossAccountAccessProfile]

--- a/doc_source/cross-account-user-b.md
+++ b/doc_source/cross-account-user-b.md
@@ -54,13 +54,13 @@ AWS CodeCommit supports Git versions 1\.7\.9 and later\. Git is an evolving, reg
    output = json
    ```
 
-   Add two lines to the profile configuration, `role_arn` and `source_profile`\. Provide the ARN of the role in AccountA you will assume to access the repository in the other account, and the name of your IAM user in AccountB\. For example:
+   Add two lines to the profile configuration, `role_arn` and `source_profile`\. Provide the ARN of the role in AccountA you will assume to access the repository in the other account, and the name of the current profile\. For example:
 
    ```
    [profile MyCrossAccountAccessProfile]
    region = US East (Ohio)
    role_arn = arn:aws:iam::111122223333:role/MyCrossAccountRepositoryContributorRole
-   source_profile = Saanvi_Sarkar
+   source_profile = MyCrossAccountAccessProfile
    output = json
    ```
 


### PR DESCRIPTION
Following the tutorial didn't work before I realize `source_profile` is the profile containing the aws credentials.
If this fix isn't enough I can provide a new version with a profile for the user and a profile for the cross account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
