### PR TITLE
Fix command line bug in issue #12

### DIFF
--- a/doc_source/cross-account-user-b.md
+++ b/doc_source/cross-account-user-b.md
@@ -94,7 +94,7 @@ If you have already installed the AWS CLI and configured a profile, you can skip
 1. Run the git config command twice: once to configure Git use the AWS CLI credential helper with the AWS CLI profile you just created, and again to use HTTP\. For example:
 
    ```
-   git config --global credential.helper "!aws codecommit credential-helper --profile MyCrossAccountAccessProfile $@"
+   git config --global credential.helper '!aws codecommit credential-helper --profile MyCrossAccountAccessProfile $@'
    ```
 
    ```


### PR DESCRIPTION
*Issue #, if available:*
Issue #12
*Description of changes:*
When using double quotes on command git config --global credential.helper "!aws codecommit credential-helper --profile MyCrossAccountAccessProfile $@" bash will expand [1] !aws to the last command ran starting with "aws". Replacing it with single quotes fixes the command.

References:
[1] Bash history expansion - https://www.gnu.org/software/bash/manual/html_node/History-Interaction.html#History-Interaction


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
