### PR TITLE
Troubleshooting cred helper update

### DIFF
--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -54,39 +54,39 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
 
 1. In Terminal, run the git config command to find the Git configuration file \(`gitconfig`\) where the Keychain Access utility is defined\. Depending on your local system and preferences, you might have more than one `gitconfig` file\. 
 
-  ```
-  git config -l --show-origin | grep credential
-  ```
-  Check for results like:
-  ```shell
-  file:/usr/local/etc/gitconfig   credential.helper=osxkeychain
-  ```
-  The file listed at the beginning of this line is the Git configuration file you must edit\.
+   ```
+   git config -l --show-origin | grep credential
+   ```
+   Check for results like:
+   ```shell
+   file:/usr/local/etc/gitconfig   credential.helper=osxkeychain
+   ```
+   The file listed at the beginning of this line is the Git configuration file you must edit\.
 
 2. To edit the Git configuration file, use a plain\-text editor or run the following command:
 
-  ```
-  nano /usr/local/git/etc/gitconfig
-  ```
+   ```
+   nano /usr/local/git/etc/gitconfig
+   ```
 
 3. Modify the configuration using one of the following strategies:
-  - Remove the credential section with "helper = osxkeychain"
-  - Update both the aws credential helper and osxkeychain credential helper to have a contexts\. For example, if it is used to authenticate to github:
-    ```
-    [credential "https://git-codecommit\.us-east-1\.amazonaws\.com"]
-      helper = !aws --profile CodeCommitProfile codecommit credential-helper $@
-      UseHttpPath = true
-    [credential "https://github\.com"]
-      helper = osxkeychain
-    ```
-    This will cause git to use the osxkeychain helper when the remote host matches the "https://github\.com" context, and aws codecommit credential-helper when the remote host matches the codecommit host\.
-  - Include an empty string helper before the aws git credential helper like so:
-    ```
-    [credential]
-      helper =
-      helper = !aws --profile CodeCommitProfile codecommit credential-helper $@
-      UseHttpPath = true
-    ```
+   - Remove the credential section with "helper = osxkeychain"
+   - Update both the aws credential helper and osxkeychain credential helper to have a contexts\. For example, if it is used to authenticate to github:
+     ```
+     [credential "https://git-codecommit\.us-east-1\.amazonaws\.com"]
+       helper = !aws --profile CodeCommitProfile codecommit credential-helper $@
+       UseHttpPath = true
+     [credential "https://github\.com"]
+       helper = osxkeychain
+     ```
+     This will cause git to use the osxkeychain helper when the remote host matches the "https://github\.com" context, and aws codecommit credential-helper when the remote host matches the codecommit host\.
+  -  Include an empty string helper before the aws git credential helper like so:
+     ```
+     [credential]
+       helper =
+       helper = !aws --profile CodeCommitProfile codecommit credential-helper $@
+       UseHttpPath = true
+     ```
 
 Alternatively If you are accessing other repositories with Git, you can configure the Keychain Access utility so that it does not supply credentials for your CodeCommit repositories\. To configure the Keychain Access utility:
 

--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -56,11 +56,11 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
    ```
    git config -l --show-origin | grep credential  
    ```  
-   Check for results like:  
+   Review the returned results and search for results similar to:  
    ```shell 
    file:/usr/local/etc/gitconfig   credential.helper=osxkeychain  
    ```  
-   The file listed at the beginning of this line is the Git configuration file you must edit\.
+   The file that appears at the beginning of this line is the Git configuration file you must edit\.
 
 2. To edit the Git configuration file, use a plain\-text editor or run the following command:
    ```
@@ -68,8 +68,8 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
    ```
 
 3. Modify the configuration using one of the following strategies:
-   - Remove the credential section with "helper = osxkeychain"
-   - Update both the aws credential helper and osxkeychain credential helper to have a contexts\. For example, if it is used to authenticate to github:
+   - Comment out the credential section with "helper = osxkeychain"
+   - Update both the aws credential helper and osxkeychain credential helper sections to have context\. For example, if osxkeychain is used to authenticate to GitHub:
      ```
      [credential "https://git-codecommit\.us-east-1\.amazonaws\.com"]
        helper = !aws --profile CodeCommitProfile codecommit credential-helper $@
@@ -77,8 +77,8 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
      [credential "https://github\.com"]
        helper = osxkeychain
      ```
-     This will cause git to use the osxkeychain helper when the remote host matches the "https://github\.com" context, and aws codecommit credential-helper when the remote host matches the codecommit host\.
-  -  Include an empty string helper before the aws git credential helper like so:
+     In this configuration, Git will use the osxkeychain helper when the remote host matches "https://github\.com" and the credential helper when the remote host matches "https://git-codecommit\.us-east-1\.amazonaws\.com"\.
+  -  Include an empty string helper before the credential helper. For example:
      ```
      [credential]
        helper =
@@ -86,7 +86,7 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
        UseHttpPath = true
      ```
 
-Alternatively If you are accessing other repositories with Git, you can configure the Keychain Access utility so that it does not supply credentials for your CodeCommit repositories\. To configure the Keychain Access utility:
+Alternatively if you are accessing other repositories with Git, you can configure the Keychain Access utility so that it does not supply credentials for your CodeCommit repositories\. To configure the Keychain Access utility:
 
 1. Open the Keychain Access utility\. \(You can use Finder to locate it\.\)
 

--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -53,14 +53,14 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
  The default version of Git released on OS X and macOS uses the Keychain Access utility to save generated credentials\. For security reasons, the password generated for access to your CodeCommit repository is temporary, so the credentials stored in the keychain stop working after about 15 minutes\. If you are only accessing Git with CodeCommit, try the following:
 
 1. In Terminal, run the git config command to find the Git configuration file \(`gitconfig`\) where the Keychain Access utility is defined\. Depending on your local system and preferences, you might have more than one `gitconfig` file\.
-   ```
-   git config -l --show-origin | grep credential
-   ```
-   Check for results like:
-   ```shell
-   file:/usr/local/etc/gitconfig   credential.helper=osxkeychain
-   ```
-   The file listed at the beginning of this line is the Git configuration file you must edit\.
+```
+git config -l --show-origin | grep credential
+```
+Check for results like:
+```shell
+file:/usr/local/etc/gitconfig   credential.helper=osxkeychain
+```
+The file listed at the beginning of this line is the Git configuration file you must edit\.
 
 2. To edit the Git configuration file, use a plain\-text editor or run the following command:
    ```

--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -54,38 +54,41 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
 
 1. In Terminal, run the git config command to find the Git configuration file \(`gitconfig`\) where the Keychain Access utility is defined\. Depending on your local system and preferences, you might have more than one `gitconfig` file\. 
 
-   ```
-   $ git config -l --show-origin
-   ```
+  ```
+  git config -l --show-origin | grep credential
+  ```
+  Check for results like:
+  ```shell
+  file:/usr/local/etc/gitconfig   credential.helper=osxkeychain
+  ```
+  The file listed at the beginning of this line is the Git configuration file you must edit\.
 
-   In the output from this command, find a line that contains the following option:
+2. To edit the Git configuration file, use a plain\-text editor or run the following command:
 
-   ```
-   helper = osxkeychain
-   ```
+  ```
+  nano /usr/local/git/etc/gitconfig
+  ```
 
-   The file listed at the beginning of this line is the Git configuration file you must edit\.
-
-1. To edit the Git configuration file, use a plain\-text editor or run the following command:
-
-   ```
-   $ nano /usr/local/git/etc/gitconfig
-   ```
-
-1. Comment out the following line of text:
-
-   ```
-   # helper = osxkeychain
-   ```
-
-   Alternatively, if you want to continue to use the Keychain Access utility to cache credentials for other Git repositories, modify the header instead of commenting out the line\. For example, to allow cached credentials for GitHub, you could modify the header as follows:
-
-   ```
-   [credential "https://github.com"]
+3. Modify the configuration using one of the following strategies:
+  - Remove the credential section with "helper = osxkeychain"
+  - Update both the aws credential helper and osxkeychain credential helper to have a contexts\. For example, if it is used to authenticate to github:
+    ```
+    [credential "https://git-codecommit\.us-east-1\.amazonaws\.com"]
+      helper = !aws --profile CodeCommitProfile codecommit credential-helper $@
+      UseHttpPath = true
+    [credential "https://github\.com"]
       helper = osxkeychain
-   ```
+    ```
+    This will cause git to use the osxkeychain helper when the remote host matches the "https://github\.com" context, and aws codecommit credential-helper when the remote host matches the codecommit host\.
+  - Include an empty string helper before the aws git credential helper like so:
+    ```
+    [credential]
+      helper =
+      helper = !aws --profile CodeCommitProfile codecommit credential-helper $@
+      UseHttpPath = true
+    ```
 
-If you are accessing other repositories with Git, you can configure the Keychain Access utility so that it does not supply credentials for your CodeCommit repositories\. To configure the Keychain Access utility:
+Alternatively If you are accessing other repositories with Git, you can configure the Keychain Access utility so that it does not supply credentials for your CodeCommit repositories\. To configure the Keychain Access utility:
 
 1. Open the Keychain Access utility\. \(You can use Finder to locate it\.\)
 

--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -52,14 +52,14 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
 
  The default version of Git released on OS X and macOS uses the Keychain Access utility to save generated credentials\. For security reasons, the password generated for access to your CodeCommit repository is temporary, so the credentials stored in the keychain stop working after about 15 minutes\. If you are only accessing Git with CodeCommit, try the following:
 
-1. In Terminal, run the git config command to find the Git configuration file \(`gitconfig`\) where the Keychain Access utility is defined\. Depending on your local system and preferences, you might have more than one `gitconfig` file\.
+1. In Terminal, run the git config command to find the Git configuration file \(`gitconfig`\) where the Keychain Access utility is defined\. Depending on your local system and preferences, you might have more than one `gitconfig` file\.  
 ```
-git config -l --show-origin | grep credential
-```
-Check for results like:
-```shell
-file:/usr/local/etc/gitconfig   credential.helper=osxkeychain
-```
+git config -l --show-origin | grep credential  
+```  
+Check for results like:  
+```shell 
+file:/usr/local/etc/gitconfig   credential.helper=osxkeychain  
+```  
 The file listed at the beginning of this line is the Git configuration file you must edit\.
 
 2. To edit the Git configuration file, use a plain\-text editor or run the following command:

--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -52,8 +52,7 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
 
  The default version of Git released on OS X and macOS uses the Keychain Access utility to save generated credentials\. For security reasons, the password generated for access to your CodeCommit repository is temporary, so the credentials stored in the keychain stop working after about 15 minutes\. If you are only accessing Git with CodeCommit, try the following:
 
-1. In Terminal, run the git config command to find the Git configuration file \(`gitconfig`\) where the Keychain Access utility is defined\. Depending on your local system and preferences, you might have more than one `gitconfig` file\. 
-
+1. In Terminal, run the git config command to find the Git configuration file \(`gitconfig`\) where the Keychain Access utility is defined\. Depending on your local system and preferences, you might have more than one `gitconfig` file\.
    ```
    git config -l --show-origin | grep credential
    ```
@@ -64,7 +63,6 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
    The file listed at the beginning of this line is the Git configuration file you must edit\.
 
 2. To edit the Git configuration file, use a plain\-text editor or run the following command:
-
    ```
    nano /usr/local/git/etc/gitconfig
    ```

--- a/doc_source/troubleshooting-ch.md
+++ b/doc_source/troubleshooting-ch.md
@@ -53,14 +53,14 @@ aws-cli/1.16.62 Python/3.6.2 Darwin/16.7.0 botocore/1.12.52
  The default version of Git released on OS X and macOS uses the Keychain Access utility to save generated credentials\. For security reasons, the password generated for access to your CodeCommit repository is temporary, so the credentials stored in the keychain stop working after about 15 minutes\. If you are only accessing Git with CodeCommit, try the following:
 
 1. In Terminal, run the git config command to find the Git configuration file \(`gitconfig`\) where the Keychain Access utility is defined\. Depending on your local system and preferences, you might have more than one `gitconfig` file\.  
-```
-git config -l --show-origin | grep credential  
-```  
-Check for results like:  
-```shell 
-file:/usr/local/etc/gitconfig   credential.helper=osxkeychain  
-```  
-The file listed at the beginning of this line is the Git configuration file you must edit\.
+   ```
+   git config -l --show-origin | grep credential  
+   ```  
+   Check for results like:  
+   ```shell 
+   file:/usr/local/etc/gitconfig   credential.helper=osxkeychain  
+   ```  
+   The file listed at the beginning of this line is the Git configuration file you must edit\.
 
 2. To edit the Git configuration file, use a plain\-text editor or run the following command:
    ```


### PR DESCRIPTION
*Issue #, if available:*
Alternative to https://github.com/awsdocs/aws-codecommit-user-guide/pull/16

*Description of changes:*
### WHY
It is possible to set up git https credentials on macos using the aws codecommit credential-helper without having osxcredential helper store expired credentials.
### HOW
Updates the docs to describe the process to do so.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
