### PR TITLE
Fixed spacing in blog hyperlink text

### DIFF
--- a/doc_source/integrations.md
+++ b/doc_source/integrations.md
@@ -64,7 +64,7 @@ These links are provided for informational purposes only, and should not be cons
   Learn how to manage your Git configuration across multiple Amazon Web Services accounts\.
 
   Published February 12, 2019
-+ **[Validating AWS CodeCommit Pull Requests with AWS CodeBuildand AWS Lambda](https://aws.amazon.com/blogs/devops/validating-aws-codecommit-pull-requests-with-aws-codebuild-and-aws-lambda/)**
++ **[Validating AWS CodeCommit Pull Requests with AWS CodeBuild and AWS Lambda](https://aws.amazon.com/blogs/devops/validating-aws-codecommit-pull-requests-with-aws-codebuild-and-aws-lambda/)**
 
   Learn how to validate pull requests with AWS CodeCommit, AWS CodeBuild, and AWS Lambda\. By running tests against the proposed changes prior to merging them into the default branch, you can help ensure a high level of quality in pull requests, catch any potential issues, and boost the confidence of the developer in relation to their changes\.
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* I added a space between the words 'CodeBuild' and 'and' for better readability for the https://aws.amazon.com/blogs/devops/validating-aws-codecommit-pull-requests-with-aws-codebuild-and-aws-lambda/ blog reference.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
