### PR TITLE
added a warning with regards to who can approve the pull request in CodeCommit

### DIFF
--- a/doc_source/how-to-create-template.md
+++ b/doc_source/how-to-create-template.md
@@ -14,6 +14,9 @@ Approval rule templates are not associated with any repository by default\. You 
 
 ## To create an approval rule template \(Console\)<a name="create-template-console"></a>
 
+**Note**  
+The pull request cannot be approved by the same individual who has created it\.
+
 1. Open the CodeCommit console at [https://console\.aws\.amazon\.com/codesuite/codecommit/home](https://console.aws.amazon.com/codesuite/codecommit/home)\.
 
 1. Choose **Approval rule templates**, and then choose **Create template**\.


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
The current documentation is not clear that the same users who created the pull request cannot approve it causing confusion as to why their rule template may not be working.

Feel free to modify the commit if you believe that the note should be worded differently or in a different place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
